### PR TITLE
Add amd64 arch support

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -8,6 +8,7 @@ class packer::params {
     'amd64'  => 'amd64',
     'x86_64' => 'amd64',
     'x86'    => '386',
+    'i386'   => '386',
     default  => 'arm'
   }
 


### PR DESCRIPTION
On Linux nodes, the `architecture` fact presents itself as `amd64`. This prevents the ARM download unnecessarily.
