### PR TITLE
Bump version to 0.5.2

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,7 +1,7 @@
 # Internal: Default configuration for packer
 
 class packer::params {
-  $version = '0.5.1'
+  $version = '0.5.2'
 
   $_real_kernel = downcase($::kernel)
   $_real_arch   = $::architecture ? {


### PR DESCRIPTION
This moves the default version of Packer to 0.5.2 from 0.5.1.
