### PR TITLE
Update uri scheme for versions of packer >= 0.7.0 take two

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -17,7 +17,12 @@ class packer(
   case $ensure {
     present: {
       # get the download URI
-      $download_uri = "http://dl.bintray.com/mitchellh/packer/${version}_${packer::params::_real_platform}.zip?direct"
+      if $version =~ /0\.[1-6]\.[0-9]/ { # version < 0.7.0
+        $download_uri = "http://dl.bintray.com/mitchellh/packer/${version}_${packer::params::_real_platform}.zip?direct"
+      }
+      else { # version >= 0.7.0
+        $download_uri = "http://dl.bintray.com/mitchellh/packer/packer_${version}_${packer::params::_real_platform}.zip?direct"
+      }
 
       # the dir inside the zipball uses the major version number segment
       $major_version = split($version, '[.]')

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,7 +1,7 @@
 # Internal: Default configuration for packer
 
 class packer::params {
-  $version = '0.6.0'
+  $version = '0.7.2'
 
   $_real_kernel = downcase($::kernel)
   $_real_arch   = $::architecture ? {

--- a/spec/classes/packer_spec.rb
+++ b/spec/classes/packer_spec.rb
@@ -15,7 +15,7 @@ describe "packer" do
       [
         "rm -rf /tmp/packer* /tmp/0",
         # download the zip to tmp
-        "curl http://dl.bintray.com/mitchellh/packer/0.9.9_darwin_amd64.zip?direct > /tmp/packer-v0.9.9.zip",
+        "curl http://dl.bintray.com/mitchellh/packer/packer_0.9.9_darwin_amd64.zip?direct > /tmp/packer-v0.9.9.zip",
         # extract the zip to tmp spot
         "mkdir /tmp/packer",
         "unzip -o /tmp/packer-v0.9.9.zip -d /tmp/packer",


### PR DESCRIPTION
I went to install packer 0.7.2 and noticed that the curl command is failing.

The packer zip files are hosted with a prefix of `packer_` now, it would appear. See the listing at https://dl.bintray.com/mitchellh/packer/

(sorry about the last pull request. tried to overwrite my username/email in the commit history and ended up rewriting the whole history)
