### PR TITLE
Update to Packer 0.7.5 and update version checking

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -42,7 +42,7 @@ class packer(
       exec {
         "install packer v${version}":
           command => $install_command,
-          unless  => "test -x ${root}/packer && ${root}/packer -v | grep '\\bv${version}\\b'",
+          unless  => "test -x ${root}/packer && ${root}/packer version | grep '\\bv${version}\\b'",
           user    => $user,
       }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -17,7 +17,7 @@ class packer(
   case $ensure {
     present: {
       # get the download URI
-      $download_uri = "http://dl.bintray.com/mitchellh/packer/${version}_${packer::params::_real_platform}.zip?direct"
+      $download_uri = "http://dl.bintray.com/mitchellh/packer/packer_${version}_${packer::params::_real_platform}.zip?direct"
 
       # the dir inside the zipball uses the major version number segment
       $major_version = split($version, '[.]')

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,7 +1,7 @@
 # Internal: Default configuration for packer
 
 class packer::params {
-  $version = '0.6.0'
+  $version = '0.7.5'
 
   $_real_kernel = downcase($::kernel)
   $_real_arch   = $::architecture ? {


### PR DESCRIPTION
- Bump the default version to the latest (0.7.5)
- Fix the construction of the download link to reflect the new link structure. This may break older versions.
- Previously packer has responded to `packer -v`, this now doesn't work and requires either `packer version` or `packer --version` - the version check is updated accordingly to avoid re-installation on every run.
