### PR TITLE
The zip file has a "packer_" prefix for all versions over 0.7.1

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -16,8 +16,13 @@ class packer(
 
   case $ensure {
     present: {
+      $archive_prefix = $version ? {
+        /0.[0-7].[0-1]/ => "",
+        default         => "packer_",
+      }
+
       # get the download URI
-      $download_uri = "http://dl.bintray.com/mitchellh/packer/${packer::params::_archive_prefix}${version}_${packer::params::_real_platform}.zip?direct"
+      $download_uri = "http://dl.bintray.com/mitchellh/packer/${archive_prefix}${version}_${packer::params::_real_platform}.zip?direct"
 
       # the dir inside the zipball uses the major version number segment
       $major_version = split($version, '[.]')

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -17,7 +17,7 @@ class packer(
   case $ensure {
     present: {
       # get the download URI
-      $download_uri = "http://dl.bintray.com/mitchellh/packer/${version}_${packer::params::_real_platform}.zip?direct"
+      $download_uri = "http://dl.bintray.com/mitchellh/packer/${packer::params::_archive_prefix}${version}_${packer::params::_real_platform}.zip?direct"
 
       # the dir inside the zipball uses the major version number segment
       $major_version = split($version, '[.]')

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -12,6 +12,11 @@ class packer::params {
     default  => 'arm'
   }
 
+  $_archive_prefix = $version ? {
+    /0.[0-7].[0-1]/ => "",
+    default         => "packer_",
+  }
+
   $_real_platform = "${_real_kernel}_${_real_arch}"
 
   case $::operatingsystem {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -12,11 +12,6 @@ class packer::params {
     default  => 'arm'
   }
 
-  $_archive_prefix = $version ? {
-    /0.[0-7].[0-1]/ => "",
-    default         => "packer_",
-  }
-
   $_real_platform = "${_real_kernel}_${_real_arch}"
 
   case $::operatingsystem {


### PR DESCRIPTION
This adds the prefix depending on which version is being requested. 

I have tested it by using it to install both Packer 0.7.2 and 0.6.0 on OSX 10.9.5.