### PR TITLE
Use curl -L

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -27,7 +27,7 @@ class packer(
         # blow away any previous attempts
         "rm -rf /tmp/packer* /tmp/${extracted_dirname}",
         # download the zip to tmp
-        "curl ${download_uri} > /tmp/packer-v${version}.zip",
+        "curl -L ${download_uri} > /tmp/packer-v${version}.zip",
         # extract the zip to tmp spot
         'mkdir /tmp/packer',
         "unzip -o /tmp/packer-v${version}.zip -d /tmp/packer",


### PR DESCRIPTION
Packer's zip file is now located in cloudfront and packer's
web site uses a 302 to redirect requests accordingly. This
commit adds -L to the curl command in order to get curl to
follow the 302 redirect.
