### PR TITLE
Curl fix

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -27,7 +27,7 @@ class packer(
         # blow away any previous attempts
         "rm -rf /tmp/packer* /tmp/${extracted_dirname}",
         # download the zip to tmp
-        "curl ${download_uri} > /tmp/packer-v${version}.zip",
+        "curl -L ${download_uri} > /tmp/packer-v${version}.zip",
         # extract the zip to tmp spot
         'mkdir /tmp/packer',
         "unzip -o /tmp/packer-v${version}.zip -d /tmp/packer",

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -17,7 +17,7 @@ class packer(
   case $ensure {
     present: {
       # get the download URI
-      $download_uri = "http://dl.bintray.com/mitchellh/packer/${version}_${packer::params::_real_platform}.zip?direct"
+      $download_uri = "http://dl.bintray.com/mitchellh/packer/packer_${version}_${packer::params::_real_platform}.zip?direct"
 
       # the dir inside the zipball uses the major version number segment
       $major_version = split($version, '[.]')

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -17,7 +17,7 @@ class packer(
   case $ensure {
     present: {
       # get the download URI
-      $download_uri = "http://dl.bintray.com/mitchellh/packer/packer_${version}_${packer::params::_real_platform}.zip?direct"
+      $download_uri = "https://dl.bintray.com/mitchellh/packer/packer_${version}_${packer::params::_real_platform}.zip?direct"
 
       # the dir inside the zipball uses the major version number segment
       $major_version = split($version, '[.]')

--- a/spec/classes/packer_spec.rb
+++ b/spec/classes/packer_spec.rb
@@ -15,7 +15,7 @@ describe "packer" do
       [
         "rm -rf /tmp/packer* /tmp/0",
         # download the zip to tmp
-        "curl http://dl.bintray.com/mitchellh/packer/0.9.9_darwin_amd64.zip?direct > /tmp/packer-v0.9.9.zip",
+        "curl http://dl.bintray.com/mitchellh/packer/packer_0.9.9_darwin_amd64.zip?direct > /tmp/packer-v0.9.9.zip",
         # extract the zip to tmp spot
         "mkdir /tmp/packer",
         "unzip -o /tmp/packer-v0.9.9.zip -d /tmp/packer",


### PR DESCRIPTION
The bintray URL now send a 302 response and redirects to a CloudFront URL. Give curl the -L option so it follows the redirect. 
